### PR TITLE
記事リストとページネーション間の余分な余白を除去

### DIFF
--- a/docs/.vitepress/theme/styles/index.css
+++ b/docs/.vitepress/theme/styles/index.css
@@ -142,6 +142,10 @@ img, video, canvas, iframe {
   margin-bottom: 50px;
 }
 
+.list-item:last-child {
+  margin-bottom: 0;
+}
+
 .item-title {
   display: inline-block;
   margin-bottom: 10px;


### PR DESCRIPTION
## 修正内容

記事リスト最後の記事とページネーション(prev/next)の間に余分な余白があった。

原因は以下の3つのマージンが合算されていたこと:
- `.list-item` の `margin-bottom: 50px`(最後の記事にも適用)
- `<ol>` のブラウザデフォルト `margin-bottom: 14px`
- `.pagination` の `margin-top: 30px`

## 対応

- `.list-item:last-child { margin-bottom: 0; }` を追加して最後の記事の下マージンを除去
- `.pagination` の `margin-top` を `30px` から `10px` に縮小

これにより、最後の記事とページネーションの間隔が自然になる。