### PR TITLE
lazy load Giscus with IntersectionObserver

### DIFF
--- a/docs/.vitepress/theme/components/Comment.vue
+++ b/docs/.vitepress/theme/components/Comment.vue
@@ -1,32 +1,46 @@
 <template>
-  <div id="giscus-comment"></div>
+  <div ref="containerRef" class="comment" />
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const containerRef = ref(null)
+let observer = null
 
 onMounted(() => {
-  let scriptEl = document.createElement('script')
-  const attributes = {
-    "src": "https://giscus.app/client.js",
-    "data-repo": "ikaruga777/ikaruga.org",
-    "data-repo-id": "MDEwOlJlcG9zaXRvcnkyMjIyMDE0NjE=",
-    "data-category": "Comments",
-    "data-category-id": "DIC_kwDODT6Gdc4CTdvt",
-    "data-mapping": "pathname",
-    "data-strict": "0",
-    "data-reactions-enabled": "1",
-    "data-emit-metadata": "0",
-    "data-input-position": "top",
-    "data-theme": "light",
-    "data-lang": "ja",
-    "data-loading": "lazy",
-    "crossorigin": "anonymous",
-    "async": "true"
-  }
-  Object.entries(attributes).forEach(attribute => {
-    scriptEl.setAttribute(attribute[0], attribute[1])
-  })
-  document.getElementById('giscus-comment').appendChild(scriptEl)
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (!entries[0].isIntersecting) return
+      observer.disconnect()
+      observer = null
+
+      const script = document.createElement('script')
+      const attributes = {
+        src: 'https://giscus.app/client.js',
+        'data-repo': 'ikaruga777/ikaruga.org',
+        'data-repo-id': 'MDEwOlJlcG9zaXRvcnkyMjIyMDE0NjE=',
+        'data-category': 'Comments',
+        'data-category-id': 'DIC_kwDODT6Gdc4CTdvt',
+        'data-mapping': 'pathname',
+        'data-strict': '0',
+        'data-reactions-enabled': '1',
+        'data-emit-metadata': '0',
+        'data-input-position': 'top',
+        'data-theme': 'light',
+        'data-lang': 'ja',
+        crossorigin: 'anonymous',
+        async: 'true',
+      }
+      Object.entries(attributes).forEach(([k, v]) => script.setAttribute(k, v))
+      containerRef.value.appendChild(script)
+    },
+    { rootMargin: '200px' }
+  )
+  observer.observe(containerRef.value)
+})
+
+onUnmounted(() => {
+  observer?.disconnect()
 })
 </script>


### PR DESCRIPTION
コメント欄がビューポートに近づくまで giscus.app/client.js の読み込みを遅らせる。rootMargin: 200px で少し手前から開始することでスクロール到達時のちらつきを防ぐ。