### PR TITLE
load embed scripts only when the page contains embeds

### DIFF
--- a/docs/.vitepress/theme/composables/useEmbeds.js
+++ b/docs/.vitepress/theme/composables/useEmbeds.js
@@ -6,13 +6,21 @@ import { useRoute } from 'vitepress'
 
 // ロード済みならAPIでDOMを再スキャンできるスクリプト
 const RESCAN_SCRIPTS = [
-  { src: 'https://platform.twitter.com/widgets.js', rescan: () => window.twttr?.widgets?.load() },
-  { src: 'https://www.instagram.com/embed.js', rescan: () => window.instgrm?.Embeds?.process() }
+  {
+    src: 'https://platform.twitter.com/widgets.js',
+    selector: 'blockquote.twitter-tweet',
+    rescan: () => window.twttr?.widgets?.load()
+  },
+  {
+    src: 'https://www.instagram.com/embed.js',
+    selector: 'blockquote.instagram-media',
+    rescan: () => window.instgrm?.Embeds?.process()
+  }
 ]
 
 // 再スキャンAPIがなく、実行時の一度だけDOMを処理するスクリプト。遷移ごとに再実行する
 const RELOAD_SCRIPTS = [
-  'https://embedr.flickr.com/assets/client-code.js'
+  { src: 'https://embedr.flickr.com/assets/client-code.js', selector: 'a[data-flickr-embed]' }
 ]
 
 function appendScript(src) {
@@ -23,14 +31,16 @@ function appendScript(src) {
 }
 
 function processEmbeds() {
-  for (const { src, rescan } of RESCAN_SCRIPTS) {
+  for (const { src, selector, rescan } of RESCAN_SCRIPTS) {
+    if (!document.querySelector(selector)) continue
     if (document.querySelector(`script[src="${src}"]`)) {
       rescan()
     } else {
       appendScript(src)
     }
   }
-  for (const src of RELOAD_SCRIPTS) {
+  for (const { src, selector } of RELOAD_SCRIPTS) {
+    if (!document.querySelector(selector)) continue
     document.querySelector(`script[src="${src}"]`)?.remove()
     appendScript(src)
   }


### PR DESCRIPTION
各スクリプトに対応する埋め込み要素のセレクタを持たせ、DOMに該当要素がないページではスクリプトの読み込み・再スキャンをスキップする。埋め込みのない大半のページでリクエストがゼロになる。