### PR TITLE
fix e2e CI: remove duplicate pnpm version from workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/e2e/post.spec.js
+++ b/e2e/post.spec.js
@@ -26,7 +26,7 @@ test.describe('記事ページ', () => {
   test('記事ページに TimeAgo コンポーネントが datetime 属性付きで表示される', async ({ page }) => {
     await page.locator('.list .item-title').first().click()
 
-    const timeEl = page.locator('.post-date time')
+    const timeEl = page.locator('time.post-date')
     await expect(timeEl).toBeVisible()
     await expect(timeEl).toHaveAttribute('datetime', /.+/)
     await expect(timeEl).toHaveAttribute('pubdate', 'pubdate')


### PR DESCRIPTION
pnpm/action-setup@v4 は package.json の packageManager フィールドから自動的にバージョンを読むため、version: 9 との二重指定でエラーになっていた。