### PR TITLE
defer Google Fonts loading to avoid render blocking

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -68,7 +68,9 @@ export default defineConfig({
 
   head: [
     ['link', { rel: 'icon', type: 'image/jpeg', href: '/icon.jpg' }],
-    ['link', { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c&display=swap' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+    ['link', { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c&display=swap', media: 'print', onload: "this.media='all'" }],
     ['link', { rel: 'alternate', type: 'application/rss+xml', title: 'ikaruga.org', href: `${DOMAIN}/rss.xml` }],
     ['script', {}, `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5C26B9M');`]
   ],


### PR DESCRIPTION
media=print + onload でレンダーブロッキングを回避し、フォントの適用はダウンロード完了後に行う。preconnect で fonts.googleapis.com / fonts.gstatic.com への接続を先行して確立する。